### PR TITLE
DE-1494: do not add keys before users

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -182,7 +182,11 @@ resource "aws_transfer_ssh_key" "all" {
   server_id  = aws_transfer_server.sftp.id
   user_name  = each.key
   body       = each.value
-  depends_on = [aws_transfer_user.write_only]
+  depends_on = [
+                   aws_transfer_user.write_only,
+                   aws_transfer_user.read_only,
+                   aws_transfer_user.read_write,
+               ]
 }
 
 resource "aws_s3_bucket" "sftp_transfer" {


### PR DESCRIPTION
based on my understanding of https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on adding a list of resources to depends_on will prevent a plan from being generated that attempts to attach keys to users before they are created, e.g. https://hbuco.atlassian.net/browse/DE-1494